### PR TITLE
Update ExpoDatawedgeModule.kt

### DIFF
--- a/android/src/main/java/expo/modules/datawedge/ExpoDatawedgeModule.kt
+++ b/android/src/main/java/expo/modules/datawedge/ExpoDatawedgeModule.kt
@@ -7,6 +7,8 @@ import android.content.IntentFilter
 import android.os.Bundle
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import androidx.core.content.ContextCompat
+import	android.os.Build
 
 class ExpoDatawedgeModule : Module() {
 
@@ -66,8 +68,12 @@ class ExpoDatawedgeModule : Module() {
                 }
             }
         }
-
-        context.registerReceiver(myBroadcastReceiver, filter)
+        //checking version of the sdk and registering receiver with RECEIVER_EXPORTED
+        if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
+            context.registerReceiver(myBroadcastReceiver, filter, ContextCompat.RECEIVER_EXPORTED)
+        }else{
+            context.registerReceiver(myBroadcastReceiver, filter)
+        }
     }
 
     private fun unregisterReceiver() {


### PR DESCRIPTION
Due to error 
As discussed at Google I/O 2023, registering receivers with intention using the RECEIVER_EXPORTED / RECEIVER_NOT_EXPORTED flag was introduced as part of Android 13 and is now a requirement for apps running on Android 14 or higher (U+).